### PR TITLE
Matchmaking beta update changes

### DIFF
--- a/resource/gamemenu.res
+++ b/resource/gamemenu.res
@@ -9,35 +9,36 @@
 	}
 	"QuickplayButton"
 	{
-		"label" "Multiplayer" 
+		"label" "Multiplayer"
 		"command" "quickplay"
 		"subimage" "glyph_multiplayer"
 		"OnlyAtMenu" "1"
 	}
 	"QuickplayChangeButton"
 	{
-		"label" "#MMenu_NewGame" 
+		"label" "#MMenu_NewGame"
 		"command" "quickplay"
 		"subimage" "glyph_server"
 		"OnlyInGame" "1"
 	}
 	"PlayPVEButton"
 	{
-		"label" "Cooperative" 
+		"label" "Cooperative"
 		"command" "playpve"
 		"subimage" "glyph_coop"
 		"OnlyAtMenu" "1"
 	}
+
 	"ServerBrowserButton"
 	{
-		"label" "Servers" 
+		"label" "Servers"
 		"command" "OpenServerBrowser"
 		"subimage" "glyph_server_browser"
 		"OnlyAtMenu" "1"
-	} 
+	}
 	"ChangeServerButton"
 	{
-		"label" "#MMenu_ChangeServer" 
+		"label" "#MMenu_ChangeServer"
 		"command" "OpenServerBrowser"
 		"subimage" "glyph_server_browser"
 		"OnlyInGame" "1"
@@ -63,13 +64,13 @@
 	}
 	"TrainingButton"
 	{
-		"label" "Training"
-		"command" "offlinepractice"
+		"label" "Matchmaking"
+		"command" "ladder_ui_show"
 		"subimage" "glyph_practice"
 		"OnlyAtMenu" "1"
 	}
-	
-	// These buttons get positioned by the MainMenuOverride.res	
+
+	// These buttons get positioned by the MainMenuOverride.res
 	"CreateServerButton"
 	{
 		"label" "Create"
@@ -81,7 +82,7 @@
 		"label" "Store"
 		"command" "engine open_store"
 		"subimage" "glyph_store"
-	}	
+	}
 	"CharacterSetupButton"
 	{
 		"label" "Items"

--- a/resource/ui/hudmatchstatus.res
+++ b/resource/ui/hudmatchstatus.res
@@ -1,0 +1,133 @@
+"Resource/UI/Competitive.res"
+{
+	"RoundSignModel"
+	{
+		"ControlName"	"CModelPanel"
+		"fieldName"		"RoundSignModel"
+		"xpos"			"0"
+		"ypos"			"0"
+		"zpos"			"3"
+		"wide"			"f0"
+		"tall"			"f0"
+		"autoResize"	"0"
+		"pinCorner"		"0"
+		"visible"		"0"
+		"enabled"		"1"
+		"fov"			"70"
+		"proportionaltoparent"	"1"
+
+		"model"
+		{
+			"modelname"	"models/props_ui/round_banner.mdl"
+			"skin"		"0"
+			"angles_x"	"30"
+			"angles_y"	"180"
+			"angles_z"	"0"
+			"origin_x"	"150"
+			"origin_y"	"0"
+			"origin_z"	"62"
+			"spotlight"	"1"
+
+			"animation"
+			{
+				"name"			"ref"
+				"sequence"		"ref"
+				"default"		"1"
+			}
+
+			"animation"
+			{
+				"name"			"intro"
+				"sequence"		"intro"
+			}
+
+			"animation"
+			{
+				"name"			"outro"
+				"sequence"		"outro"
+			}
+		}
+	}
+
+	"RoundCounter"
+	{
+		"fieldName"		"RoundCounter"
+		"xpos"			"cs-0.5"
+		"ypos"			"-2"
+		"zpos"			"1"
+		"wide"			"300"
+		"tall"			"100"
+		"visible"		"1"
+		"enabled"		"1"
+
+	}
+
+	"ObjectiveStatusTimePanel"
+	{
+		"ControlName"		"EditablePanel"
+		"fieldName"			"ObjectiveStatusTimePanel"
+		"xpos"				"c-55"
+		"xpos_hidef"		"c-150"
+		"xpos_lodef"		"c-150"
+		"ypos"				"0"	[$WIN32]
+		"ypos_minmode"		"-14"	[$WIN32]
+		"ypos"				"24"	[$X360]
+		"zpos"				"2"
+		"wide"				"110"
+		"wide_hidef"		"300"
+		"wide_lodef"		"300"
+		"tall"				"150"
+		"visible"			"0"
+		"enabled"			"1"
+		"delta_item_x"			"22"	[$WIN32]
+		"delta_item_x"			"115"	[$X360]
+		"delta_item_start_y"	"50"
+		"delta_item_end_y"		"70"
+		"PositiveColor"			"0 255 0 255"
+		"NegativeColor"			"255 0 0 255"
+		"delta_lifetime"		"1.5"
+		"delta_item_font"		"HudFontMedium"
+
+		if_comp
+		{
+			"ypos_minmode"			"0"
+			"delta_item_x"			"35"
+			"delta_item_start_y"	"12"
+			"delta_item_end_y"		"50"
+			"PositiveColor"			"0 255 0 255"
+			"NegativeColor"			"255 0 0 255"
+			"delta_lifetime"		"1.5"
+			"delta_item_font"		"HudFontMediumSmall"
+		}
+
+		"TimePanelValue"
+		{
+		"ControlName"		"CExLabel"
+		"fieldName"		"TimePanelValue"
+		"font"			"Futura20"
+		"fgcolor"		"OmpText"
+		"xpos"			"52"
+		"ypos"			"0"
+		"zpos"			"3"
+		"wide"			"46"
+		"tall"			"20"
+		"visible"		"1"
+		"enabled"		"1"
+		"textAlignment"		"center"
+		"labelText"		"0:00"
+
+			if_comp
+			{
+				"proportionaltoparent"	"1"
+
+				"xpos"			"cs-0.5"
+				"ypos"			"9"
+				"ypos_minmode"	"9"
+				"tall"			"10"
+				"font"			"HudFontSmall"
+				"font_minmode"	"HudFontSmall"
+				"font_lodef"	"HudFontSmall"
+			}
+		}
+	}
+}

--- a/scripts/hudlayout.res
+++ b/scripts/hudlayout.res
@@ -20,13 +20,35 @@
 		"ypos"	"c54"
 		"wide"	"132"
 		"tall"	"132"
-		
+
 		"xpos_minmode"	"c50"
 		"ypos_minmode"	"c37"
 		"wide_minmode"	"92"
 		"tall_minmode"	"92"
 	}
-	
+
+	MatchSummary
+	{
+		"fieldName" "MatchSummary"
+		"visible" "0"
+		"enabled" "1"
+		"xpos"	"0"
+		"ypos"	"0"
+		"wide"	"f0"
+		"tall"	"f0"
+	}
+
+	HudMatchStatus
+	{
+		"fieldName" "HudMatchStatus"
+		"visible" "1"
+		"enabled" "1"
+		"xpos"	"0"
+		"ypos"	"0"
+		"wide"	"f0"
+		"tall"	"f0"
+	}
+
 	HudObjectiveStatus
 	{
 		"fieldName" "HudObjectiveStatus"
@@ -35,9 +57,9 @@
 		"xpos"	"0"
 		"ypos"	"0"
 		"wide"	"f0"
-		"tall"	"480"
-	}	
-	
+		"tall"	"f0"
+	}
+
 	HudKothTimeStatus
 	{
 		"fieldName" "HudKothTimeStatus"
@@ -47,11 +69,11 @@
 		"ypos"	"0"
 		"wide"	"250"
 		"tall"	"32"
-		
+
 		"blue_active_xpos"			"50"
-	
+
 		"red_active_xpos"			"150"
-	}	
+	}
 
 	HudItemEffectMeter
 	{
@@ -64,12 +86,13 @@
 		"ypos_minmode"	"r50"	[$WIN32]
 		"xpos"			"r194"	[$X360]
 		"ypos"			"r74"	[$X360]
+		"zpos"			"2"
 		"wide"			"100"
 		"tall"			"50"
 		"MeterFG"		"White"
 		"MeterBG"		"Gray"
 	}
-	
+
 	HudMedicCharge
 	{
 		"fieldName"		"HudMedicCharge"
@@ -79,26 +102,26 @@
 		"ypos"			"c52" // omp -- 2 before due to low-res grid.
 		"wide"			"332"
 		"tall"			"134"
-		
+
 		"xpos_minmode"	"c-100"
 		"ypos_minmode"	"c36" // omp -- 1 before due to low-res grid.
 		"wide_minmode"	"242"
 		"tall_minmode"	"93"
 	}
-	
+
 	HudDemomanCharge
 	{
 		"fieldName"		"HudDemomanCharge"
-		"visible"		"1"
+		"visible"		"0"
 		"enabled"		"1"
 		"xpos"			"c-100"
-		"ypos"			"c88"
+		"ypos"			"c80"
 		"zpos"			"1"			// draw in front of ammo
 		"wide"			"200"
 		"tall"			"6"
 		"MeterFG"		"White"
 		"MeterBG"		"Gray"
-	}	
+	}
 
 	HudBowCharge
 	{
@@ -107,7 +130,7 @@
 		"enabled"		"1"
 		"xpos"			"c-100"
 		"ypos"			"c80"
-		"zpos"			"1"			// draw in front of ammo
+		"zpos"			"2"			// draw in front of ammo
 		"wide"			"200"
 		"tall"			"6"
 		"MeterFG"		"White"
@@ -184,8 +207,8 @@
 		"SelectedBoxClor" "0 0 0 220"
 		"SelectionNumberFg"	"200 187 161 255"
 		"NumberFont" "HudSelectionText"
-	}	
-	
+	}
+
 	CHudAccountPanel
 	{
 		"fieldName"				"CHudAccountPanel"
@@ -197,7 +220,7 @@
 		"enabled" 				"1"
 		"PaintBackgroundType"	"2"
 	}
-	
+
 	CHealthAccountPanel
 	{
 		"fieldName"				"CHealthAccountPanel"
@@ -211,7 +234,7 @@
 		"enabled" 				"1"
 		"PaintBackgroundType"	"2"
 	}
-	
+
 	CDamageAccountPanel
 	{
 		"fieldName"				"CDamageAccountPanel"
@@ -224,8 +247,8 @@
 		"enabled" 				"1"
 		"PaintBackgroundType"	"2"
 	}
-	
-	
+
+
 	DisguiseStatus
 	{
 		"fieldName" "DisguiseStatus"
@@ -255,7 +278,7 @@
 			"x_offset"	"20"
 		}
 	}
-	
+
 	CSpectatorTargetID
 	{
 		"fieldName" 	"CSpectatorTargetID"
@@ -267,11 +290,11 @@
 		"tall"	 	"40"
 		"priority"	"40"
 		"priority_lodef" "35"
-		
+
 		"x_offset" "20"
 		"y_offset" "20"
 	}
-	
+
 	CSecondaryTargetID
 	{
 		"fieldName" 	"CSecondaryTargetID"
@@ -291,7 +314,7 @@
 		}
 
 	}
-	
+
 	BuildingStatus_Spy
 	{
 		"fieldName" "BuildingStatus_Spy"
@@ -301,10 +324,10 @@
 		"ypos"		"0"
 		"wide"		"640"
 		"tall"		"480"
-		
+
 		"PaintBackgroundType"	"2"
 	}
-	
+
 	BuildingStatus_Engineer
 	{
 		"fieldName" "BuildingStatus_Engineer"
@@ -314,10 +337,10 @@
 		"ypos"		"0"
 		"wide"		"640"
 		"tall"		"480"
-		
+
 		"PaintBackgroundType"	"2"
 	}
-	
+
 	HudMannVsMachineStatus
 	{
 		"fieldName" "HudMannVsMachineStatus"
@@ -328,10 +351,10 @@
 		"zpos"		"1"
 		"wide"		"f0"
 		"tall"		"480"
-		
+
 		"PaintBackgroundType"	"2"
 	}
-	
+
 	HudProgressBar
 	{
 		"fieldName" "HudProgressBar"
@@ -356,10 +379,10 @@
 		"tall"  "40"
 		"visible" "1"
 		"enabled" "1"
-		
+
 		"PaintBackgroundType"	"2"
 
-		"FlashColor" "HudIcon_Red"		
+		"FlashColor" "HudIcon_Red"
 
 		"icon_xpos"		"0"
 		"icon_ypos"		"2"
@@ -367,7 +390,7 @@
 		"digit_ypos"	"2"
 	}
 
-	HudScenarioIcon 
+	HudScenarioIcon
 	{
 		"fieldName" "HudScenarioIcon"
 		"xpos"	"c110"
@@ -379,9 +402,9 @@
 
 		"PaintBackgroundType"	"2"
 
-		"IconColor"				"Hostage_Yellow"	
+		"IconColor"				"Hostage_Yellow"
 	}
-	
+
 	HudFlashlight
 	{
 		"fieldName" "HudFlashlight"
@@ -391,7 +414,7 @@
 		"ypos"	"370"
 		"wide"	"102"
 		"tall"	"20"
-		
+
 		"text_xpos" "8"
 		"text_ypos" "6"
 		"TextColor"	"255 170 0 220"
@@ -413,10 +436,10 @@
 		"tall"  "50"
 		"visible" "1"
 		"enabled" "1"
-		
+
 		"PaintBackgroundType"	"2"
 		"BackgroundOverrideColor" "0 0 0 128"
-		
+
 		"bar_xpos"		"50"
 		"bar_ypos"		"20"
 		"bar_height"	"8"
@@ -425,10 +448,10 @@
 		"speaker_ypos"	"8"
 		"count_xpos_from_right"	"10"	// Counts from the right side
 		"count_ypos"	"8"
-		
+
 		"icon_texture"	"vgui/hud/icon_commentary"
 		"icon_xpos"		"0"
-		"icon_ypos"		"0"		
+		"icon_ypos"		"0"
 		"icon_width"	"40"
 		"icon_height"	"40"
 
@@ -472,9 +495,9 @@
 		"LineSpacing"	  "3"
 		"CornerRadius"	  "0"
 		"RightJustify"	  "1"	// If 1, draw notices from the right
-		
+
 		"TextFont"		"Default"
-		
+
 		"TeamBlue"		"HUDBlueTeamSolid"
 		"TeamRed"		"HUDRedTeamSolid"
 		"IconColor"		"255 255 255 255"
@@ -562,12 +585,12 @@
 		"zpos" 	"2"
 		"xpos"			"10"
 		"ypos"			"r30"
-		
+
 		"TextFont"				"Default"
 		"ItemFont"				"Default"
 		"ItemFontPulsing"		"Default"
 	}
-	
+
 	HudCloseCaption
 	{
 		"fieldName" "HudCloseCaption"
@@ -589,7 +612,7 @@
 		"topoffset"		"0"
 	}
 
-	HudHistoryResource 
+	HudHistoryResource
 	{
 		"fieldName" "HudHistoryResource"
 		"visible" "0"
@@ -682,7 +705,7 @@
 		"wide"	 "640"
 		"tall"	 "480"
 	}
-	
+
 	HudScopeCharge
 	{
 		"fieldName" "HudScopeCharge"
@@ -693,7 +716,7 @@
 		"wide"	 "64"
 		"tall"	 "128"
 	}
-	
+
 	HudVoiceSelfStatus
 	{
 		"fieldName" "HudVoiceSelfStatus"
@@ -720,21 +743,21 @@
 		"tall" "400"
 
 		"item_wide"	"135"
-		
+
 		"show_avatar"		"0"
-		
+
 		"show_dead_icon"	"1"
 		"dead_xpos"			"1"
 		"dead_ypos"			"0"
 		"dead_wide"			"16"
 		"dead_tall"			"16"
-		
+
 		"show_voice_icon"	"1"
 		"icon_ypos"			"0"
 		"icon_xpos"			"15"
 		"icon_tall"			"16"
 		"icon_wide"			"16"
-		
+
 		"text_xpos"			"33"
 	}
 
@@ -752,7 +775,7 @@
 		"text_ypos"				"8"
 		"center_x"				"0"	// center text horizontally
 		"center_y"				"-1"	// align text on the bottom
-	}	
+	}
 
 	HudHintKeyDisplay
 	{
@@ -771,7 +794,7 @@
 
 		"PaintBackgroundType"	"2"
 	}
-	
+
 	overview
 	{
 		"fieldname" "overview"
@@ -782,7 +805,7 @@
 		"wide"	"640"
 		"tall"	"480"
 	}
-	
+
 	VguiScreenCursor
 	{
 		"fieldName" "VguiScreenCursor"
@@ -818,12 +841,12 @@
 		"enabled"				"1"
 		"icon_space"			"2"
 	}
-	
+
 	HUDAutoAim
 	{
 
-	}	
-	
+	}
+
 	HudHDRDemo
 	{
 
@@ -850,7 +873,7 @@
 		"wide"					"360"
 		"tall"					"132"
 	}
-	
+
 	PVEWinPanel
 	{
 		"fieldName"				"PVEWinPanel"
@@ -874,7 +897,7 @@
 		"tall"					"120"
 		"tall_lodef"			"190"
 	}
-	
+
 	FreezePanel
 	{
 		"fieldName"				"FreezePanel"
@@ -907,10 +930,10 @@
 		"wide"					"100"
 		"tall"					"50"
 	}
-	
+
 	AnnotationsPanel
 	{
-		
+
 	}
 
 	WaitingForPlayersPanel
@@ -923,7 +946,7 @@
 		"wide"					"292"
 		"tall"					"64"
 	}
-	
+
 	"HudUpgradePanel"
 	{
 		"fieldName"		"HudUpgradePanel"
@@ -932,7 +955,7 @@
 		"xpos"			"c-200"
 		"ypos"			"260"
 		"wide"			"400"
-		"tall"			"160"		
+		"tall"			"160"
 	}
 
 	"HudChat"
@@ -948,7 +971,7 @@
 		"tall"	 		"120"
 		"PaintBackgroundType"	"2"
 	}
-	
+
 	"HudMenuEngyBuild"
 	{
 		"fieldName" 	"HudMenuEngyBuild"
@@ -961,7 +984,7 @@
 		"tall"			"108"
 		"PaintBackgroundType"	"0"
 	}
-	
+
 	"HudMenuEngyDestroy"
 	{
 		"fieldName" 	"HudMenuEngyDestroy"
@@ -987,7 +1010,7 @@
 		"tall"			"108"
 		"PaintBackgroundType"	"0"
 	}
-	
+
 	"HudMenuSpyDisguise"
 	{
 		"fieldName" 	"HudMenuSpyDisguise"
@@ -999,8 +1022,8 @@
 		"wide"			"260"
 		"tall"			"88"
 		"PaintBackgroundType"	"0"
-	}	
-	
+	}
+
 	HudDemomanPipes
 	{
 		"fieldName"		"HudDemomanPipes"
@@ -1010,7 +1033,7 @@
 		"ypos"			"c64" // omp -- 2 before due to low-res grid.
 		"wide"			"200"
 		"tall"			"30"
-	}	
+	}
 
 	HudTeamGoal
 	{
@@ -1118,7 +1141,7 @@
 		"wide"					"125"
 		"tall"					"20"
 	}
-	
+
 	NotificationPanel
 	{
 		"fieldName"				"NotificationPanel"
@@ -1130,7 +1153,7 @@
 		"tall"					"100"
 	}
 
-	AchievementNotificationPanel	
+	AchievementNotificationPanel
 	{
 		"fieldName"				"AchievementNotificationPanel"
 		"visible"				"1"
@@ -1144,7 +1167,7 @@
 
 	CriticalPanel [$WIN32]
 	{
-		"fieldName"				"CriticalPanel"		
+		"fieldName"				"CriticalPanel"
 		"visible"				"1"
 		"enabled"				"1"
 		"xpos"					"r155"
@@ -1152,10 +1175,10 @@
 		"wide"					"150"
 		"tall"					"25"
 	}
-	
+
 	HudArenaClassLayout [$WIN32]
 	{
-		"fieldName"				"HudArenaClassLayout"		
+		"fieldName"				"HudArenaClassLayout"
 		"visible"				"1"
 		"enabled"				"1"
 		"xpos"					"0"
@@ -1163,10 +1186,10 @@
 		"wide"					"f0"
 		"tall"					"320"
 	}
-	
+
 	HudArenaVsPanel [$WIN32]
 	{
-		"fieldName"				"HudArenaVsPanel"		
+		"fieldName"				"HudArenaVsPanel"
 		"visible"				"1"
 		"enabled"				"1"
 		"xpos"					"0"
@@ -1174,18 +1197,18 @@
 		"wide"					"f0"
 		"tall"					"240"
 	}
-	
+
 	HudArenaPlayerCount [$WIN32]
 	{
-		"fieldName"				"HudArenaPlayerCount"		
+		"fieldName"				"HudArenaPlayerCount"
 		"visible"				"1"
 		"enabled"				"1"
 		"xpos"					"0"
 		"ypos"					"0"
 		"wide"					"f0"
 		"tall"					"50"
-	}	
-	
+	}
+
 	"HudAchievementTracker"
 	{
 		"ControlName"	"EditablePanel"
@@ -1197,9 +1220,9 @@
 		"wide"			"200"
 		"tall"			"280"
 		"visible"		"1"
-		"enabled"		"1"	
+		"enabled"		"1"
 	}
-	
+
 	HudTrainingInfoMsg
 	{
 		"fieldName"				"HudTrainingInfoMsg"
@@ -1210,15 +1233,15 @@
 		"wide"					"200"
 		"tall"					"300"
 	}
-	
+
 	HudTrainingMsg
 	{
-		
+
 	}
-	
+
 	TrainingComplete
 	{
-		
+
 	}
 
 	HudInspectPanel
@@ -1232,7 +1255,7 @@
 		"wide"					"200"
 		"tall"					"1000"
 	}
-	
+
 	HudTFCrosshair
 	{
 		"fieldName" "HudTFCrosshair"
@@ -1241,7 +1264,7 @@
 		"wide"	 "640"
 		"tall"	 "480"
 	}
-	
+
 	ItemQuickSwitchPanel
 	{
 		"fieldName"				"ItemQuickSwitchPanel"
@@ -1252,14 +1275,14 @@
 		"wide"			"250"
 		"tall"			"160"
 	}
-	
+
 	ReplayReminder
 	{
 		"fieldName"		"ReplayReminder"
 		"visible"		"0"
 		"enable"		"1"
 	}
-	
+
 	MainMenuAdditions
 	{
 		"fieldName"		"MainMenuAdditions"
@@ -1270,7 +1293,7 @@
 		"zpos"			"0"
 		"wide"			"300"
 		"tall"			"100"
-	}	
+	}
 
 	CoachedByPanel
 	{
@@ -1305,11 +1328,11 @@
 		"wide"			"200"
 		"tall"			"0"
 	}
-	
+
 	"CHudVote"
 	{
 		"fieldName"		"CHudVote"
-		"xpos"			"0"			
+		"xpos"			"0"
 		"ypos"			"0"
 		"wide"			"640"
 		"tall"			"480"
@@ -1334,7 +1357,7 @@
 	"CTFKillStreakNotice"
 	{
 		"fieldName"		"CTFKillStreakNotice"
-		"xpos"			"0"			
+		"xpos"			"0"
 		"ypos"			"0"
 		"wide"			"640"
 		"tall"			"480"
@@ -1389,7 +1412,7 @@
 		"enabled" "0"
 		"textAlignment" "center"
 	}
-	
+
 	"OmpCrosshairDot"
 	{
 		"controlName" "CExLabel"


### PR DESCRIPTION
The following is what I have changed:

- Added HudMatchStatus to scripts/hudlayout.res to reflect the changes to the round timer
- Changed "Training" button on main menu to "Matchmaking," and changed its function from "offlinepractice" to "ladder_ui_show"
- Made the Huntsman and Pipe charge bar overlap with the huntsman's bar the highest so that only one appears at the same time when playing Huntsman Sniper. Known issue is that the bar has a higher opacity due to the overlap. There was no other workaround that would have been cleaner in my best research
- added resource/ui/hudmatchstatus.res, edited it with the old settings for the round timer to look like the timer from resource/ui/hudobjectivestatus.res