### PR TITLE
Fixes position of round timer in minmode

### DIFF
--- a/resource/ui/hudmatchstatus.res
+++ b/resource/ui/hudmatchstatus.res
@@ -70,7 +70,7 @@
 		"xpos_hidef"		"c-150"
 		"xpos_lodef"		"c-150"
 		"ypos"				"0"	[$WIN32]
-		"ypos_minmode"		"-14"	[$WIN32]
+		"ypos_minmode"		"0"	[$WIN32]
 		"ypos"				"24"	[$X360]
 		"zpos"				"2"
 		"wide"				"110"


### PR DESCRIPTION
The round timer in minmode before the update was not positioned on the screen. It now works. The minmode timer is the same size as the non minmode timer, but the minmode timer seems to be the same as before for me.
